### PR TITLE
Variable Crop Sizes for Zoom Level Testing

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,9 @@ NUM_CLASSES = 5  # (1,2,3,4) for label types, 0 for null crops
 # name of training session for saving purposes
 TRAIN_SESSION_NAME = "TRAIN SESSION NAME HERE"
 
+# for zoom testing
+CROP_SIZE = 1500
+
 # check for GPU
 if torch.cuda.is_available():  
   dev = "cuda" 
@@ -54,14 +57,15 @@ checkpoint_save_path = BASE_PATH + TRAIN_SESSION_NAME + ".pt"
 # =================================================================================================
 # load train datasets
 image_transform = transforms.Compose([
-  transforms.Resize(256),
-  transforms.CenterCrop(input_size),
+  transforms.CenterCrop(CROP_SIZE),
+  transforms.Resize(input_size),
+  # transforms.CenterCrop(input_size),
   transforms.ToTensor(),
   transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 ])
 
 # having issues with CUDA running out of memory, so lowering batch size
-batch_size = 32
+batch_size = 8
 
 train_labels_csv_path = BASE_PATH + "train_crop_info.csv"
 train_img_dir = BASE_PATH + "train_crops/"

--- a/train_binary.py
+++ b/train_binary.py
@@ -20,6 +20,9 @@ NUM_CLASSES = 2  # 1 for label type, 0 for null crops
 # name of training session for saving purposes
 TRAIN_SESSION_NAME = "TRAIN SESSION NAME HERE"
 
+# for zoom testing
+CROP_SIZE = 1500
+
 # check for GPU
 if torch.cuda.is_available():  
   dev = "cuda" 
@@ -53,8 +56,8 @@ checkpoint_save_path = BASE_PATH + TRAIN_SESSION_NAME + ".pt"
 # =================================================================================================
 # load train datasets
 image_transform = transforms.Compose([
-  transforms.Resize(256),
-  transforms.CenterCrop(input_size),
+  transforms.CenterCrop(CROP_SIZE),
+  transforms.Resize(input_size),
   transforms.ToTensor(),
   transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 ])

--- a/train_custom_architecture.py
+++ b/train_custom_architecture.py
@@ -18,6 +18,12 @@ NUM_CLASSES = 5  # (1,2,3,4) for label types, 0 for null crops
 # name of training session for saving purposes
 TRAIN_SESSION_NAME = "CoAtNet"
 
+# for zoom testing
+CROP_SIZE = 1500
+
+# specify for custom architecture being tested
+MODEL_INPUT_SIZE = 224
+
 if __name__ ==  '__main__':
   # check for GPU
   if torch.cuda.is_available():  
@@ -53,8 +59,8 @@ if __name__ ==  '__main__':
   # =================================================================================================
   # load train datasets
   image_transform = transforms.Compose([
-    transforms.Resize(256),
-    transforms.CenterCrop(224),
+    transforms.CenterCrop(CROP_SIZE),
+    transforms.Resize(MODEL_INPUT_SIZE),
     transforms.ToTensor(),
     transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
   ])

--- a/train_two_model_ensemble.py
+++ b/train_two_model_ensemble.py
@@ -18,6 +18,9 @@ NUM_CLASSES = 5  # (1,2,3,4) for label types, 0 for null crops
 # name of training session for saving purposes
 TRAIN_SESSION_NAME = "PairedTwoModelEnsembleNet"
 
+# for zoom testing
+CROP_SIZE = 1500
+
 if __name__ ==  '__main__':
   # check for GPU
   if torch.cuda.is_available():  
@@ -55,8 +58,8 @@ if __name__ ==  '__main__':
   # =================================================================================================
   # load train datasets
   image_transform = transforms.Compose([
-    transforms.Resize(256),
-    transforms.CenterCrop(224),
+    transforms.CenterCrop(CROP_SIZE),
+    transforms.Resize(input_size),
     transforms.ToTensor(),
     transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
   ])


### PR DESCRIPTION
Add crop size as a global variable for testing zoom levels to the train scripts. Also changed the transform strategy from resizing then center cropping to the input size to just center cropping to the desired zoom "level" (crop size) and resizing immediately to input size.