### PR TITLE
adds temperature to calculations

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -92,7 +92,7 @@ if cm is not None:
 
 precisions = []
 recalls = []
-for prob_cutoff in torch.linspace(.001, .999, 1000):
+for prob_cutoff in torch.linspace(0, 1, 100000):
   precision, recall = get_precision_recall(output_probabilities, corresponding_ground_truths, prob_cutoff)
   precisions.append(precision)
   recalls.append(recall)

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -263,6 +263,12 @@ def evaluate(model, is_inception, loss_func, dataset_loader, test, mistakes_save
   # correct predictions.
   correct = 0
   total_loss = 0
+
+  temperature = 40
+  def softmax_with_temperature(outputs):
+    e_x = torch.exp(outputs / temperature)
+    return e_x / torch.sum(e_x)
+
   with torch.no_grad():
     for inputs, labels, paths in dataset_loader:
       if is_two_model_ensemble:
@@ -281,7 +287,7 @@ def evaluate(model, is_inception, loss_func, dataset_loader, test, mistakes_save
       # we ignore aux output in test loss calculation
       # since we aren't updating weights
       loss = loss_func(outputs, labels)
-      batch_probabilities = nn.functional.softmax(outputs, dim=1)
+      batch_probabilities = softmax_with_temperature(outputs)
       confidences, predictions = torch.max(batch_probabilities, 1)
 
       all_output_probabilities = torch.cat((all_output_probabilities, batch_probabilities[:, 1].cpu()), dim=0)


### PR DESCRIPTION
This temperature factor (https://stats.stackexchange.com/questions/527080/what-is-the-role-of-temperature-in-softmax) serves to bring the output probabilities closer to .5 to make it easier to plot precision vs recall. These values cannot exactly be interpreted as probabilities anymore, though their relative magnitudes are preserved.